### PR TITLE
(feat,pom,test) make tests compatible with embedded MongoDB up to 4.0.x

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,4 +4,4 @@ container:
   memory: 4
 
 test_task:
-  script: sh ./mvnw clean test
+  script: sh ./mvnw clean test -Pembed-linux,metrics

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-script: "./mvnw clean test -Pcoverage -B"
+script: "./mvnw clean test -Pembed-linux,metrics,coverage -B"
 
 cache:
   directories:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -5,7 +5,7 @@ First, go to project's root and make the `do.sh` utility script executable: `chm
 
 ### Manually
 
-* Install **JDK8** and **MongoDB 3.4**+. MongoDB should listen on port 27017, accept username `root` and password `woot` on the `manondev` database (authentication and data). See `src/main/resources/application-dev.yml` for details.  
+* Install **JDK8** and **MongoDB 4.0.x** (it should work with any version from 3.4.x to 4.1.x). MongoDB should listen on port 27017, with no authentication. See `src/main/resources/application-dev.yml` for details.  
 * Package and run application via `do rd`. Application will start on port 8080 with `dev` Spring profile.
   * To run with another Spring profile (e.g. `prod`), package application via `do p`, go to `target/` directory and run `java -jar -Xms128m -Xmx512m -Dspring.profiles.active=prod,metrics manon.jar`.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
   - mvnw clean package -DskipTests
 
 test_script:
-  - mvnw test
+  - mvnw test -Pembed-win,metrics
 
 cache:
   - C:\Users\appveyor\.m2

--- a/do.cmd
+++ b/do.cmd
@@ -19,11 +19,11 @@ if [%1] == [help] (
 
 if [%1] == [t] (
   echo mvnw clean test
-  mvnw clean test
+  mvnw clean test -Pembed-win
 )
 if [%1] == [tc] (
   echo mvnw clean test -Pcoverage
-  mvnw clean test -Pcoverage
+  mvnw clean test -PPembed-win,coverage
 )
 if [%1] == [b] (
   echo mvnw clean compile -DskipTests -T1
@@ -54,11 +54,11 @@ if [%1] == [w] (
 )
 if [%1] == [cv] (
   echo mvnw versions:display-property-updates -U -P coverage,jib
-  mvnw versions:display-property-updates -U -P coverage,jib
+  mvnw versions:display-property-updates -U -P coverage,jib,embed-win
 )
 if [%1] == [uv] (
   echo mvnw versions:update-properties -U -P coverage,jib
-  mvnw versions:update-properties -U -P coverage,jib
+  mvnw versions:update-properties -U -P coverage,jib,embed-win
 )
 if [%1] == [dt] (
   echo mvnw dependency:tree

--- a/do.sh
+++ b/do.sh
@@ -23,12 +23,12 @@ case "$1" in
 
 "t")
   echo "sh ./mvnw clean test"
-  sh ./mvnw clean test
+  sh ./mvnw clean test -Pembed-linux
   ;;
 
 "tc")
   echo "sh ./mvnw clean test -Pcoverage"
-  sh ./mvnw clean test -Pcoverage
+  sh ./mvnw clean test -Pembed-linux,coverage
   ;;
 
 "b")
@@ -65,12 +65,12 @@ case "$1" in
 
 "cv")
   echo "sh ./mvnw versions:display-property-updates -U -P coverage,jib"
-  sh ./mvnw versions:display-property-updates -U -P coverage,jib
+  sh ./mvnw versions:display-property-updates -U -P coverage,jib,embed-linux
   ;;
 
 "uv")
   echo "sh ./mvnw versions:update-properties -U -P coverage,jib"
-  sh ./mvnw versions:update-properties -U -P coverage,jib
+  sh ./mvnw versions:update-properties -U -P coverage,jib,embed-linux
   ;;
 
 "dt")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   # database
   mongo:
     container_name: mongo
-    image: mongo:3.4-jessie
+    image: mongo:4.0.3-xenial
     command: --smallfiles --logpath=/dev/null
     ports:
     - "27017:27017"

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,8 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <surefireArgLine>
-            -ea -Xms128m -Xmx256m -Dspring.profiles.active=test,metrics -Dfile.encoding=UTF-8
-            -Djava.awt.headless=true -XX:TieredStopAtLevel=1 -noverify
-        </surefireArgLine>
+        <surefireArgLine>-ea -Xms128m -Xmx256m -Dfile.encoding=UTF-8 -Djava.awt.headless=true -XX:TieredStopAtLevel=1 -noverify</surefireArgLine>
+        <profileArgLine>-Dspring.profiles.active=test,metrics</profileArgLine>
 
         <embed.mongo.version>2.1.1</embed.mongo.version>
         <janino.version>3.0.10</janino.version>
@@ -38,7 +36,6 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
-
     </properties>
 
     <dependencies>
@@ -172,12 +169,6 @@
             <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>${embed.mongo.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
         <!-- Annotations. -->
@@ -245,7 +236,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <argLine>${surefireArgLine}</argLine>
+                    <argLine>${surefireArgLine} ${profileArgLine}</argLine>
                     <workingDirectory>${project.build.directory}</workingDirectory>
                 </configuration>
             </plugin>
@@ -263,6 +254,37 @@
     </build>
 
     <profiles>
+
+        <!-- Tests with embedded MongoDB: since 3.6, Linux and Windows versions need different startup params. -->
+        <profile>
+            <id>embed-linux</id>
+            <properties>
+                <profileArgLine>-Dspring.profiles.active=test-embed-linux,metrics</profileArgLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>de.flapdoodle.embed</groupId>
+                    <artifactId>de.flapdoodle.embed.mongo</artifactId>
+                    <version>${embed.mongo.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>embed-win</id>
+            <properties>
+                <profileArgLine>-Dspring.profiles.active=test-embed-win,metrics</profileArgLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>de.flapdoodle.embed</groupId>
+                    <artifactId>de.flapdoodle.embed.mongo</artifactId>
+                    <version>${embed.mongo.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
         <profile>
             <id>coverage</id>
             <activation>
@@ -318,13 +340,14 @@
                         <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <!--suppress MavenModelInspection -->
-                            <argLine>${surefireArgLine} ${coverageSurefireArgLine}</argLine>
+                            <argLine>${surefireArgLine} ${profileArgLine} ${coverageSurefireArgLine}</argLine>
                             <workingDirectory>${project.build.directory}</workingDirectory>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>jib</id>
             <activation>
@@ -362,6 +385,7 @@
                 </plugins>
             </build>
         </profile>
+
         <!--profile>
             <id>java11</id>
             <properties>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,4 @@
-### DEV CONFIGURATION for local application ###  (warning: avoid tabs, indent with two spaces)
+### DEV CONFIGURATION for local application with existing MongoDB ###  (warning: avoid tabs, indent with two spaces)
 
 spring:
   data:
@@ -6,6 +6,3 @@ spring:
       host: localhost
       port: 27017
       database: manondev
-      username: root
-      password: woot
-      authentication-database: manondev

--- a/src/test/resources/application-test-embed-linux.yml
+++ b/src/test/resources/application-test-embed-linux.yml
@@ -1,0 +1,10 @@
+### DEV CONFIGURATION for local unit testing with embedded MongoDB on Linux x64 ###  (warning: avoid tabs, indent with two spaces)
+
+manon:
+  security.bcrypt.strength: 4
+
+spring:
+  mongodb:
+    embedded:
+      version: 4.0.3
+      features: ["sync_delay", "ONLY_WITH_SSL", "NO_HTTP_INTERFACE_ARG"]

--- a/src/test/resources/application-test-embed-win.yml
+++ b/src/test/resources/application-test-embed-win.yml
@@ -1,0 +1,10 @@
+### DEV CONFIGURATION for local unit testing with embedded MongoDB on Windows x64 ###  (warning: avoid tabs, indent with two spaces)
+
+manon:
+  security.bcrypt.strength: 4
+
+spring:
+  mongodb:
+    embedded:
+      version: 4.0.3
+      features: ["sync_delay", "ONLY_WITH_SSL", "ONLY_WINDOWS_2008_SERVER", "NO_HTTP_INTERFACE_ARG"]

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,11 @@
-### DEV CONFIGURATION for local unit testing ###  (warning: avoid tabs, indent with two spaces)
+### DEV CONFIGURATION for local unit testing with existing MongoDB ###  (warning: avoid tabs, indent with two spaces)
 
 manon:
   security.bcrypt.strength: 4
 
 spring:
-  mongodb.embedded.version: 3.4.17
+  data:
+    mongodb:
+      host: localhost
+      port: 27017
+      database: manontest


### PR DESCRIPTION
Add profiles to use embedded MongoDB on Linux and Windows, otherwise an existing MongoDB server is used (with no authentication).
Local development now use MongoDB with no authentication.